### PR TITLE
translate float literals

### DIFF
--- a/test/cases/translate/c_style_cast.c
+++ b/test/cases/translate/c_style_cast.c
@@ -3,10 +3,9 @@ int int_from_float(float a) {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn int_from_float(arg_a: f32) c_int {
 //     var a = arg_a;
 //     _ = &a;
-//     return @as(c_int, @intFromFloat(a));
+//     return @intFromFloat(a);
 // }

--- a/test/cases/translate/floats.c
+++ b/test/cases/translate/floats.c
@@ -4,9 +4,8 @@ int c = 3.1415;
 double d = 3;
 
 // translate
-// expect=fail
 //
-// pub export var a: f32 = @as(f32, @floatCast(3.1415));
+// pub export var a: f32 = @floatCast(3.1415);
 // pub export var b: f64 = 3.1415;
-// pub export var c: c_int = @as(c_int, @intFromFloat(3.1415));
+// pub export var c: c_int = @intFromFloat(3.1415);
 // pub export var d: f64 = 3;


### PR DESCRIPTION
I can switch this to be more like the Clang version (i.e. not use Aro's print) if that is preferred.