### PR TITLE
Translate struct/union/array initializers and improve zero values

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.14.0-dev.2179+f2b81f57f",
     .dependencies = .{
         .aro = .{
-            .url = "git+https://github.com/Vexu/arocc.git#80174363f3f8a93faf2cf8f57648e254afb31a5e",
-            .hash = "1220353cb3467b77f7f9f0fb7bc30806fb2fc18b159fe95804783a18dec4db36429a",
+            .url = "git+https://github.com/Vexu/arocc.git#2d6a1daa1a244af750c364fe3cc0845a4e2feb35",
+            .hash = "1220d973f5c528ba15fa67cebd60be721c79b8cfb0f9e8f99fb7526b8f9af3e160c6",
         },
     },
     .paths = .{

--- a/src/Translator.zig
+++ b/src/Translator.zig
@@ -1653,10 +1653,10 @@ fn transExpr(t: *Translator, scope: *Scope, expr: Node.Index, used: ResultUsed) 
 
             break :res try ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, buf.items));
         },
-        .default_init_expr => |default_init| try t.transDefaultInit(scope, default_init, used, .with_as),
-        .array_init_expr => |array_init| try t.transArrayInit(scope, array_init, used),
-        .union_init_expr => |union_init| try t.transUnionInit(scope, union_init, used),
-        .struct_init_expr => |struct_init| try t.transStructInit(scope, struct_init, used),
+        .default_init_expr => |default_init| return t.transDefaultInit(scope, default_init, used, .with_as),
+        .array_init_expr => |array_init| return t.transArrayInit(scope, array_init, used),
+        .union_init_expr => |union_init| return t.transUnionInit(scope, union_init, used),
+        .struct_init_expr => |struct_init| return t.transStructInit(scope, struct_init, used),
         else => {
             if (t.tree.value_map.get(expr)) |val| {
                 // TODO handle other values
@@ -2246,8 +2246,8 @@ fn transDefaultInit(
     suppress_as: SuppressCast,
 ) TransError!ZigNode {
     assert(used == .used);
-    const @"type" = try t.transType(scope, default_init.qt, default_init.last_tok);
-    return try t.transZeroValue(default_init.qt, @"type", suppress_as);
+    const type_node = try t.transType(scope, default_init.qt, default_init.last_tok);
+    return try t.transZeroValue(default_init.qt, type_node, suppress_as);
 }
 
 fn transArrayInit(

--- a/test/cases/translate/array_initializer_expr.c
+++ b/test/cases/translate/array_initializer_expr.c
@@ -1,10 +1,14 @@
 static void foo(void){
     char arr[10] ={1};
     char *arr1[10] ={0};
+    int arr2[5] = {0, [1] = 1, [3] = 3, 4};
+    int arr3[6] = {0, [0] = 10, [2] = 2, [0] = 100, 4, 5};
+    int arr4[7] = {[1] = 1, [2] = 2, [5] = 5};
+    int arr5[0] = {};
+    int arr6[9] = {};
 }
 
 // translate
-// expect=fail
 //
 // pub fn foo() callconv(.c) void {
 //     var arr: [10]u8 = [1]u8{
@@ -15,4 +19,30 @@ static void foo(void){
 //         null,
 //     } ++ [1][*c]u8{null} ** 9;
 //     _ = &arr1;
+//     var arr2: [5]c_int = [2]c_int{
+//         0,
+//         1,
+//     } ++ [1]c_int{0} ** 1 ++ [2]c_int{
+//         3,
+//         4,
+//     };
+//     _ = &arr2;
+//     var arr3: [6]c_int = [4]c_int{
+//         100,
+//         4,
+//         2,
+//         5,
+//     } ++ [1]c_int{0} ** 2;
+//     _ = &arr3;
+//     var arr4: [7]c_int = [1]c_int{0} ** 1 ++ [2]c_int{
+//         1,
+//         2,
+//     } ++ [1]c_int{0} ** 2 ++ [1]c_int{
+//         5,
+//     } ++ [1]c_int{0} ** 1;
+//     _ = &arr4;
+//     var arr5: [0]c_int = .{};
+//     _ = &arr5;
+//     var arr6: [9]c_int = [1]c_int{0} ** 9;
+//     _ = &arr6;
 // }

--- a/test/cases/translate/circular_struct_definitions.c
+++ b/test/cases/translate/circular_struct_definitions.c
@@ -11,9 +11,9 @@ struct Bar {
 // translate
 //
 // pub const struct_Bar = extern struct {
-//     next: [*c]struct_Foo = @import("std").mem.zeroes([*c]struct_Foo),
+//     next: [*c]struct_Foo = null,
 // };
 // 
 // pub const struct_Foo = extern struct {
-//     next: [*c]struct_Bar = @import("std").mem.zeroes([*c]struct_Bar),
+//     next: [*c]struct_Bar = null,
 // };

--- a/test/cases/translate/double_define_struct.c
+++ b/test/cases/translate/double_define_struct.c
@@ -12,13 +12,13 @@ struct Bar {
 // translate
 //
 // pub const struct_Foo = extern struct {
-//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+//     a: [*c]Foo = null,
 // };
 // 
 // pub const Foo = struct_Foo;
 // 
 // pub const struct_Bar = extern struct {
-//     a: [*c]Foo = @import("std").mem.zeroes([*c]Foo),
+//     a: [*c]Foo = null,
 // };
 // 
 // pub const Bar = struct_Bar;

--- a/test/cases/translate/empty union initializer list.c
+++ b/test/cases/translate/empty union initializer list.c
@@ -8,7 +8,6 @@ void foo(void) {
 }
 // translate
 // target=x86_64-linux
-// expect=fail
 //
 // pub const union_U = extern union {
 //     x: c_int,

--- a/test/cases/translate/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
+++ b/test/cases/translate/global_struct_whose_default_name_conflicts_with_global_is_mangled.c
@@ -6,7 +6,7 @@ const char *struct_foo = "hello world";
 // translate
 //
 // pub const struct_foo_1 = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
 // };
 // pub export var struct_foo: [*c]const u8 = "hello world";
 // pub const foo = struct_foo_1;

--- a/test/cases/translate/large_packed_struct.c
+++ b/test/cases/translate/large_packed_struct.c
@@ -10,10 +10,10 @@ struct __attribute__((packed)) bar {
 // translate
 //
 // pub const struct_bar = extern struct {
-//     a: c_short align(1) = @import("std").mem.zeroes(c_short),
-//     b: f32 align(1) = @import("std").mem.zeroes(f32),
-//     c: f64 align(1) = @import("std").mem.zeroes(f64),
-//     x: c_short align(1) = @import("std").mem.zeroes(c_short),
-//     y: f32 align(1) = @import("std").mem.zeroes(f32),
-//     z: f64 align(1) = @import("std").mem.zeroes(f64),
+//     a: c_short align(1) = 0,
+//     b: f32 align(1) = 0,
+//     c: f64 align(1) = 0,
+//     x: c_short align(1) = 0,
+//     y: f32 align(1) = 0,
+//     z: f64 align(1) = 0,
 // };

--- a/test/cases/translate/nameless_struct_fields_linux.c
+++ b/test/cases/translate/nameless_struct_fields_linux.c
@@ -13,9 +13,9 @@ typedef struct ONENAMEWITHSTRUCT
 // target=native-linux
 //
 // pub const struct_NAMED = extern struct {
-//     name: c_long = @import("std").mem.zeroes(c_long),
+//     name: c_long = 0,
 // };
 // pub const NAMED = struct_NAMED;
 // pub const struct_ONENAMEWITHSTRUCT = extern struct {
-//     b: c_long = @import("std").mem.zeroes(c_long),
+//     b: c_long = 0,
 // };

--- a/test/cases/translate/nested_assignment.c
+++ b/test/cases/translate/nested_assignment.c
@@ -3,7 +3,6 @@ int foo(int *p, int x) {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn foo(arg_p: [*c]c_int, arg_x: c_int) c_int {
 //     var p = arg_p;

--- a/test/cases/translate/packed_union_nested_unpacked.c
+++ b/test/cases/translate/packed_union_nested_unpacked.c
@@ -12,7 +12,7 @@ union Foo{
 // translate
 //
 // const struct_unnamed_1 = extern struct {
-//     b: c_int = @import("std").mem.zeroes(c_int),
+//     b: c_int = 0,
 // };
 // 
 // pub const union_Foo = extern union {

--- a/test/cases/translate/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
+++ b/test/cases/translate/pointer_to_struct_demoted_opaque_due_to_bit_fields.c
@@ -10,5 +10,5 @@ struct Bar {
 // pub const struct_Foo = opaque {};
 // 
 // pub const struct_Bar = extern struct {
-//     foo: ?*struct_Foo = @import("std").mem.zeroes(?*struct_Foo),
+//     foo: ?*struct_Foo = null,
 // };

--- a/test/cases/translate/ptr_macro.c
+++ b/test/cases/translate/ptr_macro.c
@@ -1,0 +1,6 @@
+#define PTR void*
+
+// translate
+// expect=fail
+//
+// pub const PTR = ?*anyopaque;

--- a/test/cases/translate/qualified_struct_and_enum.c
+++ b/test/cases/translate/qualified_struct_and_enum.c
@@ -12,8 +12,8 @@ void func(struct Foo *a, enum Bar **b);
 // target=x86_64-linux
 //
 // pub const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
+//     y: c_int = 0,
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate/qualified_struct_and_enum_msvc.c
+++ b/test/cases/translate/qualified_struct_and_enum_msvc.c
@@ -12,8 +12,8 @@ void func(struct Foo *a, enum Bar **b);
 // target=x86_64-windows-msvc
 //
 // pub const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
+//     y: c_int = 0,
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate/scoped_record.c
+++ b/test/cases/translate/scoped_record.c
@@ -16,34 +16,32 @@ void foo() {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn foo() void {
 //     const struct_Foo = extern struct {
-//         A: c_int = @import("std").mem.zeroes(c_int),
-//         B: c_int = @import("std").mem.zeroes(c_int),
-//         C: c_int = @import("std").mem.zeroes(c_int),
+//         A: c_int = 0,
+//         B: c_int = 0,
+//         C: c_int = 0,
 //     };
 //     _ = &struct_Foo;
 //     var a: struct_Foo = struct_Foo{
-//         .A = @as(c_int, 0),
+//         .A = 0,
 //         .B = 0,
 //         .C = 0,
 //     };
 //     _ = &a;
 //     {
 //         const struct_Foo_1 = extern struct {
-//             A: c_int = @import("std").mem.zeroes(c_int),
-//             B: c_int = @import("std").mem.zeroes(c_int),
-//             C: c_int = @import("std").mem.zeroes(c_int),
+//             A: c_int = 0,
+//             B: c_int = 0,
+//             C: c_int = 0,
 //         };
 //         _ = &struct_Foo_1;
 //         var a_2: struct_Foo_1 = struct_Foo_1{
-//             .A = @as(c_int, 0),
+//             .A = 0,
 //             .B = 0,
 //             .C = 0,
 //         };
 //         _ = &a_2;
 //     }
 // }
-

--- a/test/cases/translate/scoped_typedef.c
+++ b/test/cases/translate/scoped_typedef.c
@@ -16,7 +16,6 @@ void foo() {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn foo() void {
 //     const union_unnamed_1 = extern union {
@@ -28,7 +27,7 @@ void foo() {
 //     const Foo = union_unnamed_1;
 //     _ = &Foo;
 //     var a: Foo = Foo{
-//         .A = @as(c_int, 0),
+//         .A = 0,
 //     };
 //     _ = &a;
 //     {
@@ -41,7 +40,7 @@ void foo() {
 //         const Foo_1 = union_unnamed_2;
 //         _ = &Foo_1;
 //         var a_2: Foo_1 = Foo_1{
-//             .A = @as(c_int, 0),
+//             .A = 0,
 //         };
 //         _ = &a_2;
 //     }

--- a/test/cases/translate/self_referential_struct_with_function_pointer.c
+++ b/test/cases/translate/self_referential_struct_with_function_pointer.c
@@ -3,10 +3,8 @@ struct Foo {
 };
 
 // translate
-// expect=fail
 //
 // pub const struct_Foo = extern struct {
-//     derp: ?*const fn ([*c]struct_Foo) callconv(.c) void = @import("std").mem.zeroes(?*const fn ([*c]struct_Foo) callconv(.c) void),
+//     derp: ?*const fn (foo: [*c]struct_Foo) callconv(.c) void = null,
 // };
-//
 // pub const Foo = struct_Foo;

--- a/test/cases/translate/simple_struct.c
+++ b/test/cases/translate/simple_struct.c
@@ -5,7 +5,7 @@ struct Foo {
 // translate
 //
 // const struct_Foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
 // };
 // 
 // pub const Foo = struct_Foo;

--- a/test/cases/translate/struct_in_struct_init_to_zero.c
+++ b/test/cases/translate/struct_in_struct_init_to_zero.c
@@ -4,21 +4,17 @@ struct Foo {
         int a;
     } b;
 } a = {};
-#define PTR void *
 
 // translate
-// expect=fail
 //
 // pub const struct_Bar_1 = extern struct {
-//     a: c_int = @import("std").mem.zeroes(c_int),
+//     a: c_int = 0,
 // };
 // pub const struct_Foo = extern struct {
-//     a: c_int = @import("std").mem.zeroes(c_int),
+//     a: c_int = 0,
 //     b: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),
 // };
 // pub export var a: struct_Foo = struct_Foo{
 //     .a = 0,
 //     .b = @import("std").mem.zeroes(struct_Bar_1),
 // };
-// 
-// pub const PTR = ?*anyopaque;

--- a/test/cases/translate/struct_initializer_-_packed.c
+++ b/test/cases/translate/struct_initializer_-_packed.c
@@ -1,15 +1,14 @@
 struct {int x,y,z;} __attribute__((packed)) s0 = {1, 2};
 
 // translate
-// expect=fail
 //
 // const struct_unnamed_1 = extern struct {
-//     x: c_int align(1) = @import("std").mem.zeroes(c_int),
-//     y: c_int align(1) = @import("std").mem.zeroes(c_int),
-//     z: c_int align(1) = @import("std").mem.zeroes(c_int),
+//     x: c_int align(1) = 0,
+//     y: c_int align(1) = 0,
+//     z: c_int align(1) = 0,
 // };
 // pub export var s0: struct_unnamed_1 = struct_unnamed_1{
-//     .x = @as(c_int, 1),
-//     .y = @as(c_int, 2),
+//     .x = 1,
+//     .y = 2,
 //     .z = 0,
 // };

--- a/test/cases/translate/struct_with_aligned_fields.c
+++ b/test/cases/translate/struct_with_aligned_fields.c
@@ -5,5 +5,5 @@ struct foo {
 // translate
 // 
 // pub const struct_foo = extern struct {
-//     bar: c_short align(4) = @import("std").mem.zeroes(c_short),
+//     bar: c_short align(4) = 0,
 // };

--- a/test/cases/translate/struct_with_invalid_field_alignment.c
+++ b/test/cases/translate/struct_with_invalid_field_alignment.c
@@ -21,14 +21,14 @@ struct baz {
 // target=x86_64-linux
 //
 // pub const struct_foo = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
 // };
 //
 // pub const struct_bar = extern struct {
-//     y: f32 = @import("std").mem.zeroes(f32),
+//     y: f32 = 0,
 // };
 //
 // pub const struct_baz = extern struct {
-//     z: f64 = @import("std").mem.zeroes(f64),
+//     z: f64 = 0,
 // };
 //

--- a/test/cases/translate/type_referenced_struct.c
+++ b/test/cases/translate/type_referenced_struct.c
@@ -11,7 +11,7 @@ struct Foo {
 // target=x86_64-linux-gnu
 //
 // pub const struct_Bar_1 = extern struct {
-//     b: c_int = @import("std").mem.zeroes(c_int),
+//     b: c_int = 0,
 // };
 // pub const struct_Foo = extern struct {
 //     c: struct_Bar_1 = @import("std").mem.zeroes(struct_Bar_1),

--- a/test/cases/translate/typedeffed_bool_expression.c
+++ b/test/cases/translate/typedeffed_bool_expression.c
@@ -5,13 +5,12 @@ void foo(void) {
 }
 
 // translate
-// expect=fail
 //
 // pub const yes = [*c]u8;
 // pub export fn foo() void {
 //     var a: yes = undefined;
 //     _ = &a;
 //     if (a != null) {
-//         _ = @as(c_int, 2);
+//         _ = 2;
 //     }
 // }

--- a/test/cases/translate/undefined_array_global.c
+++ b/test/cases/translate/undefined_array_global.c
@@ -1,6 +1,5 @@
 int array[100] = {};
 
 // translate
-// expect=fail
 //
 // pub export var array: [100]c_int = [1]c_int{0} ** 100;

--- a/test/cases/translate/union_initializer.c
+++ b/test/cases/translate/union_initializer.c
@@ -3,14 +3,13 @@ union { int x; char c[4]; }
   ub = {.c={'a','b','b','a'}};
 
 // translate
-// expect=fail
 //
 // const union_unnamed_1 = extern union {
 //     x: c_int,
 //     c: [4]u8,
 // };
 // pub export var ua: union_unnamed_1 = union_unnamed_1{
-//     .x = @as(c_int, 1),
+//     .x = 1,
 // };
 // pub export var ub: union_unnamed_1 = union_unnamed_1{
 //     .c = [4]u8{

--- a/test/cases/translate/union_struct_forward_decl.c
+++ b/test/cases/translate/union_struct_forward_decl.c
@@ -21,8 +21,8 @@ struct Foo {
 // translate
 //
 // pub const struct_A = extern struct {
-//     x: c_short = @import("std").mem.zeroes(c_short),
-//     y: f64 = @import("std").mem.zeroes(f64),
+//     x: c_short = 0,
+//     y: f64 = 0,
 // };
 //
 // pub const union_B = extern union {

--- a/test/cases/translate/unnamed_fields_have_predictable_names.c
+++ b/test/cases/translate/unnamed_fields_have_predictable_names.c
@@ -8,13 +8,13 @@ struct b {
 // translate
 //
 // const struct_unnamed_1 = extern struct {
-//     x: c_int = @import("std").mem.zeroes(c_int),
+//     x: c_int = 0,
 // };
 // pub const struct_a = extern struct {
 //     unnamed_0: struct_unnamed_1 = @import("std").mem.zeroes(struct_unnamed_1),
 // };
 // const struct_unnamed_2 = extern struct {
-//     y: c_int = @import("std").mem.zeroes(c_int),
+//     y: c_int = 0,
 // };
 // pub const struct_b = extern struct {
 //     unnamed_0: struct_unnamed_2 = @import("std").mem.zeroes(struct_unnamed_2),

--- a/test/cases/translate/variables.c
+++ b/test/cases/translate/variables.c
@@ -6,4 +6,4 @@ int foo;
 //
 // pub extern var extern_var: c_int;
 // pub const int_var: c_int = 13;
-// pub export var foo: c_int = @import("std").mem.zeroes(c_int);
+// pub export var foo: c_int = 0;

--- a/test/cases/translate/worst-case_postcrement_mangle_prefix.c
+++ b/test/cases/translate/worst-case_postcrement_mangle_prefix.c
@@ -4,7 +4,6 @@ void foo() {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn foo() void {
 //     var n: c_int = undefined;

--- a/test/cases/translate/worst-case_precrement_mangle_prefix.c
+++ b/test/cases/translate/worst-case_precrement_mangle_prefix.c
@@ -4,7 +4,6 @@ void foo() {
 }
 
 // translate
-// expect=fail
 //
 // pub export fn foo() void {
 //     var n: c_int = undefined;

--- a/test/cases/translate/zero_width_field_alignment.c
+++ b/test/cases/translate/zero_width_field_alignment.c
@@ -10,8 +10,8 @@ struct __attribute__((packed)) foo {
 // const struct_unnamed_1 = extern struct {};
 // const union_unnamed_2 = extern union {};
 // pub const struct_foo = extern struct {
-//     x: c_int align(1) = @import("std").mem.zeroes(c_int),
+//     x: c_int align(1) = 0,
 //     unnamed_0: struct_unnamed_1 align(1) = @import("std").mem.zeroes(struct_unnamed_1),
-//     y: f32 align(1) = @import("std").mem.zeroes(f32),
+//     y: f32 align(1) = 0,
 //     unnamed_1: union_unnamed_2 align(1) = @import("std").mem.zeroes(union_unnamed_2),
 // };

--- a/test/cases/translate/zig_keywords_in_c_code.c
+++ b/test/cases/translate/zig_keywords_in_c_code.c
@@ -5,7 +5,7 @@ struct comptime {
 // translate
 //
 // pub const struct_comptime = extern struct {
-//     @"defer": c_int = @import("std").mem.zeroes(c_int),
+//     @"defer": c_int = 0,
 // };
 // 
 // pub const @"comptime" = struct_comptime;


### PR DESCRIPTION
The `test/cases/translate/struct_in_struct_init_to_zero.c` test had an unused `PTR` macro, so I moved it to a separate test to stop it from blocking a union initializer test.

Struct initialization with named and anonymous values is affected by an upstream bug in arocc: https://github.com/Vexu/arocc/issues/842. This is the only thing stopping `test/cases/translate/struct_initializer_-_simple.c` from passing.