### PR TITLE
fix build: test and lib are required in zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -26,6 +26,8 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "test",
+        "lib",
         "LICENSE",
         "README.md",
     },


### PR DESCRIPTION
Using the package leads to below error for lib and similar for test, as these directories are not included in the package hash

```shell
error: failed to check cache: '/home/ultracode/.cache/zig/p/translate_c-0.0.0-Q_BUWkG_BwCnpe5cqlkmm-kQGOewDRnYGyKve9flXPMy/lib/c_builtins.zig' file_hash FileNotFound
error: the following command failed with 1 compilation errors:
```