### PR TITLE
Fix for Zig 0.15.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
 
     .dependencies = .{
         .aro = .{
-            .url = "git+https://github.com/Vexu/arocc#d0ebb5915074348fc7c8494415efaa569537ba2b",
-            .hash = "aro-0.0.0-JSD1QreaJwAaUgJOp3h4ZfiTG_gDocaYVqGEefWihgOQ",
+            .url = "git+https://github.com/vexu/arocc#da0aedc2625fc16beceb641823a22ccfe58a73ff",
+            .hash = "aro-0.0.0-JSD1Qv65JwB5C9GAhiWucwo6WLgu1bLgeyW6CMF3NY1j",
         },
     },
 

--- a/lib/helpers.zig
+++ b/lib/helpers.zig
@@ -228,7 +228,7 @@ fn castInt(comptime DestType: type, target: anytype) DestType {
 }
 
 fn castPtr(comptime DestType: type, target: anytype) DestType {
-    return @constCast(@volatileCast(@alignCast(@ptrCast(target))));
+    return @ptrCast(@alignCast(@constCast(@volatileCast(target))));
 }
 
 fn castToPtr(comptime DestType: type, comptime SourceType: type, target: anytype) DestType {

--- a/src/MacroTranslator.zig
+++ b/src/MacroTranslator.zig
@@ -175,7 +175,7 @@ pub fn transMacro(mt: *MacroTranslator) ParseError!void {
 }
 
 fn createMacroFn(mt: *MacroTranslator, name: []const u8, ref: ZigNode, proto_alias: *ast.Payload.Func) !ZigNode {
-    var fn_params = std.ArrayList(ast.Payload.Param).init(mt.t.gpa);
+    var fn_params = std.array_list.Managed(ast.Payload.Param).init(mt.t.gpa);
     defer fn_params.deinit();
 
     var block_scope = try Scope.Block.init(mt.t, &mt.t.global_scope.base, false);
@@ -1149,7 +1149,7 @@ fn parseCPostfixExprInner(mt: *MacroTranslator, scope: *Scope, type_name: ?ZigNo
                 if (mt.eat(.r_paren)) {
                     node = try ZigTag.call.create(mt.t.arena, .{ .lhs = node, .args = &.{} });
                 } else {
-                    var args = std.ArrayList(ZigNode).init(mt.t.gpa);
+                    var args = std.array_list.Managed(ZigNode).init(mt.t.gpa);
                     defer args.deinit();
 
                     while (true) {
@@ -1179,7 +1179,7 @@ fn parseCPostfixExprInner(mt: *MacroTranslator, scope: *Scope, type_name: ?ZigNo
 
                 // Check for designated field initializers
                 if (mt.peek() == .period) {
-                    var init_vals = std.ArrayList(ast.Payload.ContainerInitDot.Initializer).init(mt.t.gpa);
+                    var init_vals = std.array_list.Managed(ast.Payload.ContainerInitDot.Initializer).init(mt.t.gpa);
                     defer init_vals.deinit();
 
                     while (true) {
@@ -1211,7 +1211,7 @@ fn parseCPostfixExprInner(mt: *MacroTranslator, scope: *Scope, type_name: ?ZigNo
                     continue;
                 }
 
-                var init_vals = std.ArrayList(ZigNode).init(mt.t.gpa);
+                var init_vals = std.array_list.Managed(ZigNode).init(mt.t.gpa);
                 defer init_vals.deinit();
 
                 while (true) {

--- a/src/PatternList.zig
+++ b/src/PatternList.zig
@@ -91,7 +91,7 @@ const Pattern = struct {
     fn init(pl: *Pattern, allocator: mem.Allocator, template: Template) Error!void {
         const source = template[0];
         const impl = template[1];
-        var tok_list = std.ArrayList(CToken).init(allocator);
+        var tok_list = std.array_list.Managed(CToken).init(allocator);
         defer tok_list.deinit();
 
         pl.* = .{
@@ -170,7 +170,7 @@ pub fn match(pl: PatternList, ms: MacroSlicer) Error!?Impl {
     return null;
 }
 
-fn tokenizeMacro(source: []const u8, tok_list: *std.ArrayList(CToken)) Error!MacroSlicer {
+fn tokenizeMacro(source: []const u8, tok_list: *std.array_list.Managed(CToken)) Error!MacroSlicer {
     var param_count: u32 = 0;
     var param_buf: [8][]const u8 = undefined;
 
@@ -243,7 +243,7 @@ test "Macro matching" {
             source: []const u8,
             comptime expected_match: ?Impl,
         ) !void {
-            var tok_list = std.ArrayList(CToken).init(allocator);
+            var tok_list = std.array_list.Managed(CToken).init(allocator);
             defer tok_list.deinit();
             const ms = try tokenizeMacro(source, &tok_list);
             defer allocator.free(ms.tokens);

--- a/src/Translator.zig
+++ b/src/Translator.zig
@@ -500,9 +500,9 @@ fn transRecordDecl(t: *Translator, scope: *Scope, record_qt: QualType) Error!voi
         }
 
         var fields = try std.ArrayList(ast.Payload.Container.Field).initCapacity(t.gpa, record_ty.fields.len);
-        defer fields.deinit();
+        defer fields.deinit(t.gpa);
 
-        var functions = std.ArrayList(ZigNode).init(t.gpa);
+        var functions = std.array_list.Managed(ZigNode).init(t.gpa);
         defer functions.deinit();
 
         var unnamed_field_count: u32 = 0;
@@ -610,7 +610,7 @@ fn transRecordDecl(t: *Translator, scope: *Scope, record_qt: QualType) Error!voi
             const padding_bits = record_ty.layout.?.size_bits;
             const alignment_bits = record_ty.layout.?.field_alignment_bits;
 
-            try fields.append(.{
+            try fields.append(t.gpa, .{
                 .name = "_padding",
                 .type = try ZigTag.type.create(t.arena, try std.fmt.allocPrint(t.arena, "u{d}", .{padding_bits})),
                 .alignment = @divExact(alignment_bits, 8),
@@ -1015,7 +1015,7 @@ fn transStaticAssert(t: *Translator, scope: *Scope, static_assert: Node.StaticAs
         allocating.writer.end -= 1; // printString adds a terminating " so we need to remove it
         allocating.writer.writeAll("\\\"\"") catch return error.OutOfMemory;
 
-        break :str try ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.getWritten()));
+        break :str try ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.written()));
     } else try ZigTag.string_literal.create(t.arena, "\"static assertion failed\"");
 
     const assert_node = try ZigTag.static_assert.create(t.arena, .{ .lhs = condition, .rhs = diagnostic });
@@ -1030,7 +1030,7 @@ fn transGlobalAsm(t: *Translator, scope: *Scope, global_asm: Node.SimpleAsm) Err
     defer allocating.deinit();
     aro.Value.printString(bytes, global_asm.asm_str.qt(t.tree), t.comp, &allocating.writer) catch return error.OutOfMemory;
 
-    const str_node = try ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.getWritten()));
+    const str_node = try ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.written()));
 
     const asm_node = try ZigTag.asm_simple.create(t.arena, str_node);
     const block = try ZigTag.block_single.create(t.arena, asm_node);
@@ -1047,7 +1047,7 @@ fn getTypeStr(t: *Translator, qt: QualType) ![]const u8 {
     var allocating: std.Io.Writer.Allocating = .init(t.gpa);
     defer allocating.deinit();
     qt.print(t.comp, &allocating.writer) catch return error.OutOfMemory;
-    return t.arena.dupe(u8, allocating.getWritten());
+    return t.arena.dupe(u8, allocating.written());
 }
 
 fn transType(t: *Translator, scope: *Scope, qt: QualType, source_loc: TokenIndex) TypeError!ZigNode {
@@ -1799,7 +1799,7 @@ fn transSwitch(t: *Translator, scope: *Scope, switch_stmt: Node.SwitchStmt) Tran
     defer cond_scope.deinit();
     const switch_expr = try t.transExpr(&cond_scope.base, switch_stmt.cond, .used);
 
-    var cases = std.ArrayList(ZigNode).init(t.gpa);
+    var cases = std.array_list.Managed(ZigNode).init(t.gpa);
     defer cases.deinit();
     var has_default = false;
 
@@ -1813,7 +1813,7 @@ fn transSwitch(t: *Translator, scope: *Scope, switch_stmt: Node.SwitchStmt) Tran
     for (body, 0..) |stmt, i| {
         switch (stmt.get(t.tree)) {
             .case_stmt => {
-                var items = std.ArrayList(ZigNode).init(t.gpa);
+                var items = std.array_list.Managed(ZigNode).init(t.gpa);
                 defer items.deinit();
                 const sub = try t.transCaseStmt(base_scope, stmt, &items);
                 const res = try t.transSwitchProngStmt(base_scope, sub, body[i..]);
@@ -1871,7 +1871,7 @@ fn transCaseStmt(
     t: *Translator,
     scope: *Scope,
     stmt: Node.Index,
-    items: *std.ArrayList(ZigNode),
+    items: *std.array_list.Managed(ZigNode),
 ) TransError!Node.Index {
     var sub = stmt;
     var seen_default = false;
@@ -3355,7 +3355,7 @@ fn transFloatLiteral(
     defer allocating.deinit();
     _ = val.print(float_literal.qt, t.comp, &allocating.writer) catch return error.OutOfMemory;
 
-    const float_lit_node = try ZigTag.float_literal.create(t.arena, try t.arena.dupe(u8, allocating.getWritten()));
+    const float_lit_node = try ZigTag.float_literal.create(t.arena, try t.arena.dupe(u8, allocating.written()));
     if (suppress_as == .no_as) {
         return t.maybeSuppressResult(used, float_lit_node);
     }
@@ -3400,7 +3400,7 @@ fn transNarrowStringLiteral(
 
     aro.Value.printString(bytes, literal.qt, t.comp, &allocating.writer) catch return error.OutOfMemory;
 
-    return ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.getWritten()));
+    return ZigTag.string_literal.create(t.arena, try t.arena.dupe(u8, allocating.written()));
 }
 
 /// Translate a string literal that is initializing an array. In general narrow string
@@ -3449,8 +3449,8 @@ fn transStringLiteralInitializer(
         const init_list = try t.arena.alloc(ZigNode, @intCast(num_inits));
         for (init_list, 0..) |*item, i| {
             const codepoint = switch (size) {
-                2 => @as(*const u16, @alignCast(@ptrCast(bytes.ptr + i * 2))).*,
-                4 => @as(*const u32, @alignCast(@ptrCast(bytes.ptr + i * 4))).*,
+                2 => @as(*const u16, @ptrCast(@alignCast(bytes.ptr + i * 2))).*,
+                4 => @as(*const u32, @ptrCast(@alignCast(bytes.ptr + i * 4))).*,
                 else => unreachable,
             };
             item.* = try t.createCharLiteralNode(false, codepoint);
@@ -3996,7 +3996,7 @@ fn createFlexibleMemberFn(
 // =================
 
 fn transMacros(t: *Translator) !void {
-    var tok_list = std.ArrayList(CToken).init(t.gpa);
+    var tok_list = std.array_list.Managed(CToken).init(t.gpa);
     defer tok_list.deinit();
 
     var pattern_list = try PatternList.init(t.gpa);

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -798,7 +798,7 @@ pub const Payload = struct {
 pub fn render(gpa: Allocator, nodes: []const Node) !std.zig.Ast {
     var ctx: Context = .{
         .gpa = gpa,
-        .buf = std.ArrayList(u8).init(gpa),
+        .buf = std.array_list.Managed(u8).init(gpa),
     };
     defer ctx.buf.deinit();
     defer ctx.nodes.deinit(gpa);
@@ -822,7 +822,7 @@ pub fn render(gpa: Allocator, nodes: []const Node) !std.zig.Ast {
     });
 
     const root_members = blk: {
-        var result = std.ArrayList(NodeIndex).init(gpa);
+        var result = std.array_list.Managed(NodeIndex).init(gpa);
         defer result.deinit();
 
         for (nodes) |node| {
@@ -859,7 +859,7 @@ const TokenTag = std.zig.Token.Tag;
 
 const Context = struct {
     gpa: Allocator,
-    buf: std.ArrayList(u8),
+    buf: std.array_list.Managed(u8),
     nodes: std.zig.Ast.NodeList = .{},
     extra_data: std.ArrayListUnmanaged(u32) = .empty,
     tokens: std.zig.Ast.TokenList = .{},
@@ -1687,7 +1687,7 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
             }
             const l_brace = try c.addToken(.l_brace, "{");
 
-            var stmts = std.ArrayList(NodeIndex).init(c.gpa);
+            var stmts = std.array_list.Managed(NodeIndex).init(c.gpa);
             defer stmts.deinit();
             for (payload.stmts) |stmt| {
                 const res = (try renderNodeOpt(c, stmt)) orelse continue;
@@ -3035,9 +3035,9 @@ fn renderMacroFunc(c: *Context, node: Node) !NodeIndex {
     });
 }
 
-fn renderParams(c: *Context, params: []Payload.Param, is_var_args: bool) !std.ArrayList(NodeIndex) {
+fn renderParams(c: *Context, params: []Payload.Param, is_var_args: bool) !std.array_list.Managed(NodeIndex) {
     _ = try c.addToken(.l_paren, "(");
-    var rendered = try std.ArrayList(NodeIndex).initCapacity(c.gpa, @max(params.len, 1));
+    var rendered = try std.array_list.Managed(NodeIndex).initCapacity(c.gpa, @max(params.len, 1));
     errdefer rendered.deinit();
 
     for (params, 0..) |param, i| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -161,7 +161,7 @@ fn translate(d: *aro.Driver, tc: *aro.Toolchain, args: [][:0]u8) !void {
 
     var name_buf: [std.fs.max_name_bytes]u8 = undefined;
     var opt_dep_file = try d.initDepFile(source, &name_buf);
-    defer if (opt_dep_file) |*dep_file| dep_file.deinit(pp.gpa);
+    defer if (opt_dep_file) |*dep_file| dep_file.deinit(d.comp.gpa);
 
     if (opt_dep_file) |*dep_file| pp.dep_file = dep_file;
 

--- a/test/cases.zig
+++ b/test/cases.zig
@@ -162,7 +162,7 @@ fn caseFromFile(b: *std.Build, entry: std.fs.Dir.Walker.Entry) !Case {
 }
 
 fn trailing(arena: std.mem.Allocator, it: *std.mem.TokenIterator(u8, .scalar)) ![]const u8 {
-    var buf: std.ArrayList(u8) = .init(arena);
+    var buf: std.array_list.Managed(u8) = .init(arena);
     defer buf.deinit();
     while (it.next()) |line| {
         if (line.len < 3) continue;
@@ -174,9 +174,9 @@ fn trailing(arena: std.mem.Allocator, it: *std.mem.TokenIterator(u8, .scalar)) !
 }
 
 fn trailingSplit(arena: std.mem.Allocator, it: *std.mem.TokenIterator(u8, .scalar)) ![]const []const u8 {
-    var out: std.ArrayList([]const u8) = .init(arena);
+    var out: std.array_list.Managed([]const u8) = .init(arena);
     defer out.deinit();
-    var buf: std.ArrayList(u8) = .init(arena);
+    var buf: std.array_list.Managed(u8) = .init(arena);
     defer buf.deinit();
 
     while (it.next()) |line| {


### PR DESCRIPTION
Zig 0.15.1 introduced some breaking changes. The ones which matter in the context of translate-c are:

1. `std.ArrayList` was renamed to `std.array_list.Managed` (although the release notes point out that [it is supposed to be removed soon](https://ziglang.org/download/0.15.1/release-notes.html#ArrayList-make-unmanaged-the-default))
2. `std.Io.Writer.Allocating.getWritten()` was renamed to `written()`

I fixed these issues in the PR, although some tests (run with `zig build test -Dtest-cross-targets`) failed (the translator output changed slightly, e.g. introducing `@constCast`s), probably due to changes in [Aro](https://github.com/Vexu/arocc).