### PR TITLE
Translator: add todo to simple gnu asm to avoid segfault

### DIFF
--- a/src/Translator.zig
+++ b/src/Translator.zig
@@ -1549,6 +1549,10 @@ fn transStmt(t: *Translator, scope: *Scope, stmt: Node.Index) TransError!ZigNode
         .goto_stmt, .computed_goto_stmt, .labeled_stmt => {
             return t.fail(error.UnsupportedTranslation, stmt.tok(t.tree), "TODO goto", .{});
         },
+        .gnu_asm_simple,
+        => {
+            return t.fail(error.UnsupportedTranslation, stmt.tok(t.tree), "TODO asm inside function", .{});
+        },
         else => return t.transExprCoercing(scope, stmt, .unused),
     }
 }


### PR DESCRIPTION
Fix https://github.com/ziglang/translate-c/issues/196
Add todo fail to avoid unreachable case.