### PR TITLE
Translator: dereference string literal for sizeof

### DIFF
--- a/test/cases/run/sizeof.c
+++ b/test/cases/run/sizeof.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+int main(int argc, char **argv) {
+    char a[]="a";
+    char b[3]="a";
+    int c[10];
+    if (sizeof("a")!=2) abort();
+    if (sizeof(a)!=2) abort();
+    if (sizeof(b)!=3) abort();
+    if (sizeof(c)!=sizeof(int)*10) abort();
+    if (__alignof("a")!=1) abort();
+}
+
+// run


### PR DESCRIPTION
Fix #198
Derefence string literal to output correct sizeof/alignof values.
Added a run test to verify that the output is the same as c

Also fix a formatting error on my previous pull request on gnu_asm_simple