### PR TITLE
Scope: dont demangle member methods

### DIFF
--- a/src/Scope.zig
+++ b/src/Scope.zig
@@ -252,7 +252,7 @@ pub const Root = struct {
         const gpa = root.translator.gpa;
         const arena = root.translator.arena;
 
-        var member_names: std.StringArrayHashMapUnmanaged(u32) = .empty;
+        var member_names: std.StringArrayHashMapUnmanaged(void) = .empty;
         defer member_names.deinit(gpa);
         for (root.container_member_fns_map.values()) |members| {
             member_names.clearRetainingCapacity();
@@ -261,7 +261,7 @@ pub const Root = struct {
                     const payload: *ast.Payload.Container = @alignCast(@fieldParentPtr("base", members.container_decl_ptr.ptr_otherwise));
                     // Avoid duplication with field names
                     for (payload.data.fields) |field| {
-                        try member_names.put(gpa, field.name, 0);
+                        try member_names.put(gpa, field.name, {});
                     }
                     break :blk_record &payload.data.decls;
                 },
@@ -278,34 +278,39 @@ pub const Root = struct {
             };
 
             const old_decls = decls_ptr.*;
-            const new_decls = try arena.alloc(ast.Node, old_decls.len + members.member_fns.items.len);
+            const new_decls = try arena.alloc(ast.Node, old_decls.len + members.member_fns.items.len * 2);
             @memcpy(new_decls[0..old_decls.len], old_decls);
             // Assume the allocator of payload.data.decls is arena,
             // so don't add arena.free(old_variables).
             const func_ref_vars = new_decls[old_decls.len..];
             var count: u32 = 0;
+
+            // Add members without mangling them - only fields may cause name conflicts
             for (members.member_fns.items) |func| {
                 const func_name = func.data.name.?;
-
-                const last_index = std.mem.lastIndexOf(u8, func_name, "_");
-                const last_name = if (last_index) |index| func_name[index + 1 ..] else continue;
-                var same_count: u32 = 0;
-                const gop = try member_names.getOrPutValue(gpa, last_name, same_count);
-                if (gop.found_existing) {
-                    gop.value_ptr.* += 1;
-                    same_count = gop.value_ptr.*;
-                }
-                const var_name = if (same_count == 0)
-                    last_name
-                else
-                    try std.fmt.allocPrint(arena, "{s}{d}", .{ last_name, same_count });
-
+                const member_name_slot = try member_names.getOrPutValue(gpa, func_name, {});
+                if (member_name_slot.found_existing) continue;
                 func_ref_vars[count] = try ast.Node.Tag.pub_var_simple.create(arena, .{
-                    .name = var_name,
-                    .init = try ast.Node.Tag.identifier.create(arena, func_name),
+                    .name = func_name,
+                    .init = try ast.Node.Tag.root_ref.create(arena, func_name),
                 });
                 count += 1;
             }
+
+            for (members.member_fns.items) |func| {
+                const func_name = func.data.name.?;
+                const func_name_trimmed = std.mem.trimEnd(u8, func_name, "_");
+                const last_idx = std.mem.lastIndexOf(u8, func_name_trimmed, "_") orelse continue;
+                const func_name_alias = func_name[last_idx + 1 ..];
+                const member_name_slot = try member_names.getOrPutValue(gpa, func_name_alias, {});
+                if (member_name_slot.found_existing) continue;
+                func_ref_vars[count] = try ast.Node.Tag.pub_var_simple.create(arena, .{
+                    .name = func_name_alias,
+                    .init = try ast.Node.Tag.root_ref.create(arena, func_name),
+                });
+                count += 1;
+            }
+
             decls_ptr.* = new_decls[0 .. old_decls.len + count];
         }
     }

--- a/src/Translator.zig
+++ b/src/Translator.zig
@@ -223,6 +223,11 @@ pub fn translate(options: Options) mem.Allocator.Error![]u8 {
     var allocating: std.Io.Writer.Allocating = .init(gpa);
     defer allocating.deinit();
 
+    allocating.writer.writeAll(
+        \\const __root = @This();
+        \\
+    ) catch return error.OutOfMemory;
+
     if (options.module_libs) {
         allocating.writer.writeAll(
             \\pub const __builtin = @import("c_builtins");

--- a/test/cases/translate/anonymous_struct_&_unions.c
+++ b/test/cases/translate/anonymous_struct_&_unions.c
@@ -17,6 +17,7 @@ void foo(outer *x) { x->y = x->x; }
 // };
 // pub const outer = extern struct {
 //     unnamed_0: union_unnamed_1 = @import("std").mem.zeroes(union_unnamed_1),
+//     pub const foo = __root.foo;
 // };
 // pub export fn foo(arg_x: [*c]outer) void {
 //     var x = arg_x;

--- a/test/cases/translate/detect_member_func.c
+++ b/test/cases/translate/detect_member_func.c
@@ -24,15 +24,22 @@ int opa_foo_init(OpaFoo *foo);
 int opa_foo1_bar(OpaFoo foo);
 int opa_foo2_bar(OpaFoo *foo);
 
+typedef struct foo_quux FooQuux;
+
+int foo_quux_bar1(FooQuux *foo);
+int foo_quux_bar2_(FooQuux *foo);
+
 // translate
 //
 // pub const Foo = extern struct {
 //     foo: c_int = 0,
 //     bar: [*c]u8 = null,
-//     pub const bar1 = Foo_bar;
-//     pub const quux = libsomething_quux;
-//     pub const bar2 = foo1_bar;
-//     pub const bar3 = foo2_bar;
+//     pub const Foo_bar = __root.Foo_bar;
+//     pub const baz = __root.baz;
+//     pub const libsomething_quux = __root.libsomething_quux;
+//     pub const foo1_bar = __root.foo1_bar;
+//     pub const foo2_bar = __root.foo2_bar;
+//     pub const quux = __root.libsomething_quux;
 // };
 // pub extern fn Foo_bar(foo: Foo) c_int;
 // pub extern fn baz(foo: [*c]Foo) c_int;
@@ -42,18 +49,32 @@ int opa_foo2_bar(OpaFoo *foo);
 // pub const UFoo = extern union {
 //     foo: c_int,
 //     numb: f32,
-//     pub const bar = UFoo_bar;
-//     pub const quux = libsomething_union_quux;
+//     pub const UFoo_bar = __root.UFoo_bar;
+//     pub const ubaz = __root.ubaz;
+//     pub const libsomething_union_quux = __root.libsomething_union_quux;
+//     pub const bar = __root.UFoo_bar;
+//     pub const quux = __root.libsomething_union_quux;
 // };
 // pub extern fn UFoo_bar(ufoo: UFoo) c_int;
 // pub extern fn ubaz(ufoo: [*c]UFoo) c_int;
 // pub extern fn libsomething_union_quux(ufoo: [*c]UFoo) c_int;
 // pub const struct_opa_foo = opaque {
-//     pub const init = opa_foo_init;
-//     pub const bar = opa_foo1_bar;
-//     pub const bar1 = opa_foo2_bar;
+//     pub const opa_foo_init = __root.opa_foo_init;
+//     pub const opa_foo1_bar = __root.opa_foo1_bar;
+//     pub const opa_foo2_bar = __root.opa_foo2_bar;
+//     pub const init = __root.opa_foo_init;
+//     pub const bar = __root.opa_foo1_bar;
 // };
 // pub const OpaFoo = struct_opa_foo;
 // pub extern fn opa_foo_init(foo: ?*OpaFoo) c_int;
 // pub extern fn opa_foo1_bar(foo: OpaFoo) c_int;
 // pub extern fn opa_foo2_bar(foo: ?*OpaFoo) c_int;
+// pub const struct_foo_quux = opaque {
+//     pub const foo_quux_bar1 = __root.foo_quux_bar1;
+//     pub const foo_quux_bar2_ = __root.foo_quux_bar2_;
+//     pub const bar1 = __root.foo_quux_bar1;
+//     pub const bar2_ = __root.foo_quux_bar2_;
+// };
+// pub const FooQuux = struct_foo_quux;
+// pub extern fn foo_quux_bar1(foo: ?*FooQuux) c_int;
+// pub extern fn foo_quux_bar2_(foo: ?*FooQuux) c_int;

--- a/test/cases/translate/qualified_struct_and_enum.c
+++ b/test/cases/translate/qualified_struct_and_enum.c
@@ -14,6 +14,7 @@ void func(struct Foo *a, enum Bar **b);
 // pub const struct_Foo = extern struct {
 //     x: c_int = 0,
 //     y: c_int = 0,
+//     pub const func = __root.func;
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate/qualified_struct_and_enum_msvc.c
+++ b/test/cases/translate/qualified_struct_and_enum_msvc.c
@@ -14,6 +14,7 @@ void func(struct Foo *a, enum Bar **b);
 // pub const struct_Foo = extern struct {
 //     x: c_int = 0,
 //     y: c_int = 0,
+//     pub const func = __root.func;
 // };
 // pub const BarA: c_int = 0;
 // pub const BarB: c_int = 1;

--- a/test/cases/translate/simple_ptrCast_for_casts_between_opaque_types.c
+++ b/test/cases/translate/simple_ptrCast_for_casts_between_opaque_types.c
@@ -6,7 +6,9 @@ void function(struct opaque *opaque) {
 
 // translate
 //
-// pub const struct_opaque = opaque {};
+// pub const struct_opaque = opaque {
+//     pub const function = __root.function;
+// };
 // pub const struct_opaque_2 = opaque {};
 // pub export fn function(arg_opaque_1: ?*struct_opaque) void {
 //     var opaque_1 = arg_opaque_1;

--- a/test/cases/translate/struct prototype used in func.c
+++ b/test/cases/translate/struct prototype used in func.c
@@ -4,6 +4,7 @@ struct Foo *some_func(struct Foo *foo, int x);
 // translate
 //
 // pub const struct_Foo = opaque {
-//     pub const func = some_func;
+//     pub const some_func = __root.some_func;
+//     pub const func = __root.some_func;
 // };
 // pub extern fn some_func(foo: ?*struct_Foo, x: c_int) ?*struct_Foo;


### PR DESCRIPTION
closes #202
closes #212 

As discussed in https://github.com/ziglang/translate-c/pull/212#issuecomment-3453446362 and https://github.com/ziglang/translate-c/pull/22#discussion_r2064055470, it's probably better to not demangle method names