### PR TITLE
Translate binary floats as their equivalent Zig types

### DIFF
--- a/src/Translator.zig
+++ b/src/Translator.zig
@@ -1140,21 +1140,17 @@ fn transType(t: *Translator, scope: *Scope, qt: QualType, source_loc: TokenIndex
         },
         .float => |float_ty| switch (float_ty) {
             .fp16, .float16 => return ZigTag.type.create(t.arena, "f16"),
-            .float => return ZigTag.type.create(t.arena, "f32"),
-            .double => return ZigTag.type.create(t.arena, "f64"),
-            .long_double => return ZigTag.type.create(t.arena, "c_longdouble"),
+            .float, .float32 => return ZigTag.type.create(t.arena, "f32"),
+            .double, .float64, .float32x => return ZigTag.type.create(t.arena, "f64"),
+            .long_double, .float64x => return ZigTag.type.create(t.arena, "c_longdouble"),
             .float128 => return ZigTag.type.create(t.arena, "f128"),
-            .bf16,
-            .float32,
-            .float64,
-            .float32x,
-            .float64x,
-            .float128x,
+            .bf16 => return t.fail(error.UnsupportedType, source_loc, "TODO support bfloat16", .{}),
             .dfloat32,
             .dfloat64,
             .dfloat128,
             .dfloat64x,
-            => return t.fail(error.UnsupportedType, source_loc, "TODO support float type: '{s}'", .{try t.getTypeStr(qt)}),
+            => return t.fail(error.UnsupportedType, source_loc, "TODO support decimal float type: '{s}'", .{try t.getTypeStr(qt)}),
+            .float128x => unreachable, // Unsupported on all targets
         },
         .pointer => |pointer_ty| {
             const child_qt = pointer_ty.child;

--- a/test/cases/translate/float_types.c
+++ b/test/cases/translate/float_types.c
@@ -1,0 +1,46 @@
+_Float16 a;
+_Float32 b;
+_Float64 c;
+_Float128 d;
+
+_Float32x e;
+_Float64x f;
+// _Float128x g; // unsupported on all targets
+
+__fp16 h;
+__bf16 i;
+float j;
+double k;
+long double l;
+__float128 m;
+
+_Decimal32 n;
+_Decimal64 o;
+_Decimal128 p;
+_Decimal64x q;
+
+// translate
+// target=x86_64-linux
+//
+// pub export var a: f16 = 0;
+// pub export var b: f32 = 0;
+// pub export var c: f64 = 0;
+// pub export var d: f128 = 0;
+// pub export var e: f64 = 0;
+// pub export var f: c_longdouble = 0;
+// pub export var h: f16 = 0;
+// 
+// pub const i = @compileError("unable to translate variable declaration type");
+// 
+// pub export var j: f32 = 0;
+// pub export var k: f64 = 0;
+// pub export var l: c_longdouble = 0;
+// pub export var m: f128 = 0;
+// 
+// pub const n = @compileError("unable to translate variable declaration type");
+// 
+// pub const o = @compileError("unable to translate variable declaration type");
+// 
+// pub const p = @compileError("unable to translate variable declaration type");
+// 
+// pub const q = @compileError("unable to translate variable declaration type");


### PR DESCRIPTION
Actually closes #224

Note that these types are properly supported by Aro there won't be typedefs for them.