### PR TITLE
ast: don't add semicolons to static assertion blocks

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -2424,7 +2424,7 @@ fn renderNullSentinelArrayType(c: *Context, len: u64, elem_type: Node) !NodeInde
 fn addSemicolonIfNeeded(c: *Context, node: Node) !void {
     switch (node.tag()) {
         .warning => unreachable,
-        .var_decl, .var_simple, .arg_redecl, .alias, .block, .empty_block, .block_single, .@"switch", .wrapped_local, .mut_str => {},
+        .static_assert, .var_decl, .var_simple, .arg_redecl, .alias, .block, .empty_block, .block_single, .@"switch", .wrapped_local, .mut_str => {},
         .while_true => {
             const payload = node.castTag(.while_true).?.data;
             return addSemicolonIfNotBlock(c, payload);

--- a/test/cases/translate/_Static_assert.c
+++ b/test/cases/translate/_Static_assert.c
@@ -1,7 +1,16 @@
 _Static_assert(1 == 1, "");
 
+void my_function() {
+    _Static_assert(2 + 2 * 2 == 6, "Math is hard");
+}
+
 // translate
 //
 // comptime {
 //     if (!(@as(c_int, 1) == @as(c_int, 1))) @compileError("static assertion failed \"\"");
+// }
+// pub export fn my_function() void {
+//     comptime {
+//         if (!((@as(c_int, 2) + (@as(c_int, 2) * @as(c_int, 2))) == @as(c_int, 6))) @compileError("static assertion failed \"Math is hard\"");
+//     }
 // }

--- a/test/cases/translate/unsupport_declare_statement_at_the_last_of_a_compound_statement_which_belongs_to_a_statement_expr.c
+++ b/test/cases/translate/unsupport_declare_statement_at_the_last_of_a_compound_statement_which_belongs_to_a_statement_expr.c
@@ -12,6 +12,6 @@ void somefunc(void) {
 //         y = 1;
 //         comptime {
 //             if (!(@as(c_int, 1) != 0)) @compileError("static assertion failed");
-//         };
+//         }
 //     }
 // }


### PR DESCRIPTION
Closes #220

`_Static_assert`s inside function bodies are rendered with a trailing semicolon, yielding syntactically invalid zig code.

Fixed by not appending a semicolon to static assertions in `addSemicolonIfNeeded()`